### PR TITLE
Fixes for #8739

### DIFF
--- a/concrete/src/Page/Cloner.php
+++ b/concrete/src/Page/Cloner.php
@@ -165,7 +165,7 @@ class Cloner
         }
 
         $tree = $page->getSiteTreeObject();
-        if (is_object($tree) && $tree instanceof SkeletonTree) {
+        if ($tree instanceof SkeletonTree) {
             // Add a relation between the pages.
             // Is there already a relation used by the source page?
             $relation = $this->entityManager->getRepository('Concrete\Core\Entity\Page\Relation\SiblingRelation')

--- a/concrete/src/Page/Cloner.php
+++ b/concrete/src/Page/Cloner.php
@@ -5,6 +5,7 @@ use Concrete\Core\Area\Area;
 use Concrete\Core\Block\Block;
 use Concrete\Core\Entity\Attribute\Value\PageValue;
 use Concrete\Core\Entity\Page\Relation\SiblingRelation;
+use Concrete\Core\Entity\Site\SkeletonTree;
 use Concrete\Core\Localization\Service\Date as DateHelper;
 use Concrete\Core\Multilingual\Page\Section\Section;
 use Concrete\Core\Page\Collection\Collection;

--- a/concrete/src/Page/ClonerOptions.php
+++ b/concrete/src/Page/ClonerOptions.php
@@ -183,7 +183,7 @@ class ClonerOptions
      */
     public function setCopyPageTypeComposerOutputBlocks($copyPageTypeComposerOutputBlocks)
     {
-        $this->copyPageTypeComposerOutputBlocks = $copyPageTypeComposerOutputBlocks;
+        $this->copyPageTypeComposerOutputBlocks = (bool) $copyPageTypeComposerOutputBlocks;
     }
 
 


### PR DESCRIPTION
First things I noted.
I don't see a `Concrete\Core\Page\SkeletonTree` class, so I think we are missing a "use" statement. Is this the correct one?

I'm still checking the changes for #8739